### PR TITLE
[BUGFIX] Prevent undefined array key exception

### DIFF
--- a/Classes/Hook/FileListButtonListener.php
+++ b/Classes/Hook/FileListButtonListener.php
@@ -203,7 +203,7 @@ class FileListButtonListener
      */
     private function getCurrentFolder(): Folder
     {
-        $folderId = $GLOBALS['TYPO3_REQUEST']?->getQueryParams()['id'] ?? $_GET['id'];
+        $folderId = $GLOBALS['TYPO3_REQUEST']?->getQueryParams()['id'] ?? $_GET['id'] ?? null;
         if (isset($folderId)) {
             return $this->resourceFactory->getFolderObjectFromCombinedIdentifier($folderId);
         }


### PR DESCRIPTION
When calling the filelist initially it is possible, that the parameter id is not set. In order to prevent an exception the button should just not be displayed instead.