### PR TITLE
[BUGFIX] Respect read-only filemount permissions for easydb button

### DIFF
--- a/Classes/Hook/FileListButtonListener.php
+++ b/Classes/Hook/FileListButtonListener.php
@@ -69,6 +69,12 @@ class FileListButtonListener
             return $buttons;
         }
         try {
+            $currentFolder = $this->getCurrentFolder();
+            if (!$currentFolder->checkActionPermission('write')
+                || !$currentFolder->getStorage()->checkUserActionPermission('add', 'File')
+            ) {
+                return $buttons;
+            }
             $button = GeneralUtility::makeInstance(LinkButton::class);
             $button->setShowLabelText(true);
             $button->setIcon($this->iconFactory->getIcon('actions-file-add', Icon::SIZE_SMALL));


### PR DESCRIPTION
The "Add files from easydb 5 / fylr" button was shown even on read-only filemounts, while TYPO3 core correctly hides "Upload Files", "Create Folder", and "Create File" buttons. Add the same permission checks (folder write and storage-level file add) that TYPO3 core uses in FileListController before rendering the button.