### PR TITLE
[BUGFIX] Catch FolderDoesNotExistException in getCurrentFolder

### DIFF
--- a/Classes/Hook/FileListButtonListener.php
+++ b/Classes/Hook/FileListButtonListener.php
@@ -19,6 +19,7 @@ use TYPO3\CMS\Core\Imaging\IconFactory;
 use TYPO3\CMS\Core\Localization\LanguageService;
 use TYPO3\CMS\Core\Localization\LanguageServiceFactory;
 use TYPO3\CMS\Core\Page\PageRenderer;
+use TYPO3\CMS\Core\Resource\Exception\FolderDoesNotExistException;
 use TYPO3\CMS\Core\Resource\Exception\InsufficientFolderAccessPermissionsException;
 use TYPO3\CMS\Core\Resource\Folder;
 use TYPO3\CMS\Core\Resource\ResourceFactory;
@@ -193,7 +194,11 @@ class FileListButtonListener
     {
         $folderId = $GLOBALS['TYPO3_REQUEST']?->getQueryParams()['id'] ?? $_GET['id'] ?? null;
         if (isset($folderId)) {
-            return $this->resourceFactory->getFolderObjectFromCombinedIdentifier($folderId);
+            try {
+                return $this->resourceFactory->getFolderObjectFromCombinedIdentifier($folderId);
+            } catch (FolderDoesNotExistException) {
+                return $this->getRootLevelFolder();
+            }
         }
         return $this->getRootLevelFolder();
     }


### PR DESCRIPTION
When a folder is selected and then deleted via context menu, the page reloads with the deleted folder's ID still in the query parameters. getCurrentFolder() tries to resolve this non-existent folder and throws FolderDoesNotExistException.

Fall back to the root level folder when the requested folder no longer exists.

## Steps to reproduce

1. Navigate to the **Filelist** module in the TYPO3 backend
2. **Click on a folder** to select it (e.g. `user_upload/test/`) — this sets the `id` query parameter in the URL
3. **Right-click** the selected folder to open the context menu
4. Choose **Delete** and confirm the deletion
5. The page reloads with the deleted folder's ID still in the URL → exception is thrown